### PR TITLE
Set GLTF exporter to use active scene to avoid including ovbake objects

### DIFF
--- a/Development/openvat/core.py
+++ b/Development/openvat/core.py
@@ -391,7 +391,8 @@ def export_vat_model(file_format='FBX', include_materials=False, include_tangent
             export_cameras=False,
             export_lights=False,
             export_extras=False,
-            will_save_settings=False
+            will_save_settings=False,
+            use_active_scene=True
         )
 
     else:


### PR DESCRIPTION
I found that when exporting with GLTF, the ovbake objects would be included. I've fixed this by adding the setting to use the active scene when exporting with GLTF