### PR TITLE
Fix normals implementation on Godot shader.

### DIFF
--- a/OpenVAT-Engine_Tools/GLSL/VertexAnimationPBR-GLSL.gdshader
+++ b/OpenVAT-Engine_Tools/GLSL/VertexAnimationPBR-GLSL.gdshader
@@ -22,7 +22,6 @@ uniform sampler2D metallic_texture;
 uniform float specular;
 
 varying vec2 v_vat_uv_offset;
-varying vec3 v_vat_normal;
 
 void vertex() {
     // Get the current time and calculate the current frame
@@ -66,26 +65,22 @@ void vertex() {
     VERTEX += object_space_position;
 
     //// Sample the VAT normal texture and unpack the normals using UV2
-    vec3 VAT_normal = texture(vat_position_texture, VAT_UV_offset + .5f).rgb;
-	vec3 VAT_normal_next = texture(vat_position_texture, VAT_UV_offset_next + .5f).rgb;
+    vec3 VAT_normal = texture(vat_position_texture, VAT_UV_offset + .5f).rbg;
+	vec3 VAT_normal_next = texture(vat_position_texture, VAT_UV_offset_next + .5f).rbg;
     VAT_normal = 2.0 * VAT_normal - 1.0; // Unpack the normals from [0, 1] to [-1, 1]
 	VAT_normal_next = 2.0 * VAT_normal_next - 1.0; // Unpack the normals from [0, 1] to [-1, 1]
-    VAT_normal.r = -VAT_normal.r; // Flip the R channel
+    VAT_normal.b = -VAT_normal.b; // Flip the b channel
+    VAT_normal_next.b = -VAT_normal_next.b;
 
-    // Pass the unpacked normals to the fragment shader
-    v_vat_normal = normalize(mix(VAT_normal,VAT_normal_next, blend));
+    NORMAL = normalize(mix(VAT_normal,VAT_normal_next, blend));
 }
 
 void fragment() {
     vec2 base_uv = UV;
     vec4 albedo_tex = texture(base_color_texture,base_uv);
     ALBEDO = albedo.rgb * albedo_tex.rgb;
-    vec3 normal_map = texture(normal_map_texture, UV).rgb;
-        // Convert normal map from [0,1] range to [-1,1] range
-    vec3 local_normal = normalize(normal_map * 2.0 - 1.0);
+    NORMAL_MAP = texture(normal_map_texture, UV).rgb;
     
-    // Combine VAT normal with the normal map
-    vec3 combined_normal = normalize(v_vat_normal + local_normal);
     float metallic_tex = dot(texture(metallic_texture,base_uv),metallic_texture_channel);
     METALLIC = metallic_tex * metallic;
     vec4 roughness_texture_channel = vec4(1.0,0.0,0.0,0.0);


### PR DESCRIPTION
### What?
Fixed the normals implementation on the Godot shader.

### Why?
The existing shader did not properly read encoded normals data into Godot.

### How?

1. OpenVAT encodes vertex normals in a z-up coordinate system, while Godot uses a y-up coordinate system. This leads to normals rotated 90 degrees on the X axis on import. Fixing this was just swizzling rgb to rbg upon texture read, and flipping the blue channel rather than the red channel.
2. To save overhead, I've modified the shader to apply normals per vertex rather than per pixel using a varying. This also lets us use Godot's built in NORMAL_MAP implementation rather than pulling in the varying vec3 normals from the vertex function and doing them from scratch in the fragment function.

### Testing?

New implementation on the left, old implementation on the right. Note that the old implementation actually didn't work with the imported normals at all as it never applied them in the fragment function.

[Screencast_20250915_170747.webm](https://github.com/user-attachments/assets/7553de11-1e9c-4cf3-b11c-d909a9279439)

